### PR TITLE
Changed output format to root array

### DIFF
--- a/fpuzzles-fow-bulb.user.js
+++ b/fpuzzles-fow-bulb.user.js
@@ -22,7 +22,7 @@
 
             if (puzzle[id]) {
                 if (puzzle[id].length) {
-                    puzzle.fogofwar = {cells: puzzle[id].map(({cell}) => cell)};
+                    puzzle.fogofwar = puzzle[id].map(({cell}) => cell);
                 }
                 delete puzzle[id];
             }

--- a/fpuzzles-fow-bulb.user.js
+++ b/fpuzzles-fow-bulb.user.js
@@ -35,8 +35,8 @@
             const puzzle = JSON.parse(compressor.decompressFromBase64(string));
 
             if (puzzle.fogofwar) {
-                if (puzzle.fogofwar.cells && puzzle.fogofwar.cells.length) {
-                    puzzle[id] = puzzle.fogofwar.cells.map(cell => ({cell}));
+                if (Array.isArray(puzzle.fogofwar)) {
+                    puzzle[id] = puzzle.fogofwar.map(cell => ({cell}));
                 }
                 delete puzzle.fogofwar;
             }


### PR DESCRIPTION
Changed from
"fogofwar":{"cells":[]}
to
"fogofwar":[]
format to bring feature in line with others

This is supported as of SudokuPad v0.218.1